### PR TITLE
Rollback revert of execution after delete in composite

### DIFF
--- a/operator/v1/composite_operator.go
+++ b/operator/v1/composite_operator.go
@@ -184,6 +184,7 @@ func (co *CompositeOperator) Cleanup(ctx context.Context, obj client.Object) (re
 	defer span.End()
 
 	if !co.IsSuspended(ctx, obj) {
+		defer co.order.Reverse()
 		return co.executor.ExecuteOperands(co.order.Reverse(), operand.CallCleanup, ctx, obj, metav1.OwnerReference{})
 	}
 	return


### PR DESCRIPTION
Otherwise after a delete operation the will change order forever, so next ensure would fail.