### PR TITLE
CTRL-273 Handle finalizer update error

### DIFF
--- a/controller/composite/v1/controller_test.go
+++ b/controller/composite/v1/controller_test.go
@@ -253,7 +253,7 @@ func TestReconcile(t *testing.T) {
 				m.EXPECT().Default(gomock.Any(), gomock.Any())
 				m.EXPECT().Validate(gomock.Any(), gomock.Any()).Return(nil)
 			},
-			wantResult: ctrl.Result{},
+			wantResult: ctrl.Result{Requeue: true},
 		},
 		{
 			name:         "finalizer cleanup failure",
@@ -297,7 +297,7 @@ func TestReconcile(t *testing.T) {
 				m.EXPECT().Validate(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().Cleanup(gomock.Any(), gomock.Any())
 			},
-			wantResult: ctrl.Result{},
+			wantResult: ctrl.Result{Requeue: true},
 		},
 	}
 

--- a/controller/composite/v1/reconcile_test.go
+++ b/controller/composite/v1/reconcile_test.go
@@ -50,6 +50,7 @@ func TestCleanupHandler(t *testing.T) {
 			},
 			wantFinalizers: []string{finalizerName},
 			wantUpdated:    true,
+			wantResult:     ctrl.Result{Requeue: true},
 			expectations:   func(m *mocks.MockController) {},
 		},
 		{
@@ -91,6 +92,7 @@ func TestCleanupHandler(t *testing.T) {
 			wantFinalizers: []string{someFinalizerX},
 			wantDelEnabled: true,
 			wantUpdated:    true,
+			wantResult:     ctrl.Result{Requeue: true},
 			expectations: func(m *mocks.MockController) {
 				m.EXPECT().Cleanup(gomock.Any(), gomock.Any())
 			},
@@ -120,6 +122,7 @@ func TestCleanupHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a fake client with some existing objects.
 			cli := fake.NewClientBuilder().
+				WithObjects(tc.obj).
 				WithScheme(scheme).
 				Build()
 


### PR DESCRIPTION
In some cases finalizer update should go wrong.

Here is the log message:
```
"logger":"controllers.StorageOSCluster","msg":"failed to remove finalizer","library":"github.com/storageos/operator/controllers","spanName":"StorageosCluster.SetupWithManager","reconciler":"storageoscluster-controller","library":"github.com/ondat/operator-toolkit/controller/composite","spanName":"cleanupHandler","error":"Operation cannot be fulfilled on storageosclusters.storageos.com \"storageoscluster-sample\": the object has been modified; please apply your changes to the latest version and try again"}
```

As you see, the operator toolkit doesn’t have proper error handling at this point:
```
if updateErr := c.client.Update(ctx, obj); updateErr != nil {
	log.Error(updateErr, "failed to remove finalizer")
}
// Mark API object update.
updated = true
```
It always returns true
```
if updated {
	log.Info("Finalizers updated")
	skipStatusUpdate = true
}
if updated || delEnabled || cErr != nil {
	result = cResult
	reterr = cErr
	return
}
```

We need error handling to be able to re-reconcile the object.
We have to requeue object if finalizer has changed.