### PR TITLE
Add BlockingOperands to CompositeOperator

### DIFF
--- a/operator/v1/composite_operator_test.go
+++ b/operator/v1/composite_operator_test.go
@@ -222,9 +222,14 @@ func TestCompositeOperatorEnsure(t *testing.T) {
 			// A, B, C and C requires A.
 			mA.EXPECT().Name().Return("opA").AnyTimes()
 			mA.EXPECT().Requires().Return([]string{})
+			mA.EXPECT().Requires().Return([]string{})
+
 			mB.EXPECT().Name().Return("opB").AnyTimes()
 			mB.EXPECT().Requires().Return([]string{})
+			mB.EXPECT().Requires().Return([]string{})
+
 			mC.EXPECT().Name().Return("opC").AnyTimes()
+			mC.EXPECT().Requires().Return([]string{"opA"})
 			mC.EXPECT().Requires().Return([]string{"opA"})
 
 			// Set the expectations on the mocked operands.

--- a/operator/v1/executor/executor.go
+++ b/operator/v1/executor/executor.go
@@ -78,7 +78,7 @@ func (exe *Executor) ExecuteOperands(
 		var res *ctrl.Result
 
 		// failedOperands are the operands that have failed during this step.
-		failedOperands := make(map[string]bool)
+		var failedOperands map[string]bool
 
 		requeueStrategy := operand.StepRequeueStrategy(ops)
 

--- a/operator/v1/executor/executor.go
+++ b/operator/v1/executor/executor.go
@@ -54,6 +54,7 @@ func NewExecutor(e ExecutionStrategy, r record.EventRecorder) *Executor {
 // call to Ensure or Delete.
 func (exe *Executor) ExecuteOperands(
 	order operand.OperandOrder,
+	blockers operand.BlockingOperands,
 	call operand.OperandRunCall,
 	ctx context.Context,
 	obj client.Object,
@@ -76,6 +77,9 @@ func (exe *Executor) ExecuteOperands(
 		// caller.
 		var res *ctrl.Result
 
+		// failedOperands are the operands that have failed during this step.
+		failedOperands := make(map[string]bool)
+
 		requeueStrategy := operand.StepRequeueStrategy(ops)
 
 		span.AddEvent(
@@ -88,19 +92,25 @@ func (exe *Executor) ExecuteOperands(
 		switch exe.execStrategy {
 		case Serial:
 			// Run the operands serially.
-			res, execErr = exe.serialExec(ops, call, ctx, obj, ownerRef)
+			res, failedOperands, execErr = exe.serialExec(ops, call, ctx, obj, ownerRef)
 		case Parallel:
 			// Run the operands concurrently.
-			res, execErr = exe.concurrentExec(ops, call, ctx, obj, ownerRef)
+			res, failedOperands, execErr = exe.concurrentExec(ops, call, ctx, obj, ownerRef)
 		default:
 			rerr = fmt.Errorf("unknown operands execution strategy: %v", exe.execStrategy)
 			return
 		}
-
 		if execErr != nil {
+			rerr = kerrors.NewAggregate([]error{rerr, execErr})
+			// Check if any failed operands are also blocking operands.
+			// If so, we break (ie block the step) instead of proceeding to the next step.
+			// Otherwise, continue to the next step in the order.
+			// In either case, the result is to requeue.
 			result = ctrl.Result{Requeue: true}
-			rerr = execErr
-			break
+			if failuresContainBlockingOperand(failedOperands, blockers) {
+				break
+			}
+			continue
 		}
 
 		// If a change was made with a Result received after the execution and
@@ -116,6 +126,16 @@ func (exe *Executor) ExecuteOperands(
 	return
 }
 
+// failuresContainBlockingOperand returns true if a blocking operand is also a failed operand.
+func failuresContainBlockingOperand(failedOperands map[string]bool, blockers operand.BlockingOperands) bool {
+	for operandName, isBlocker := range blockers {
+		if failed, ok := failedOperands[operandName]; ok && failed && isBlocker {
+			return true
+		}
+	}
+	return false
+}
+
 // serialExec runs the given set of operands serially with the given call
 // function. An event is used to know if a change was applied. When an event is
 // found, a result object is returned, else nil.
@@ -125,11 +145,13 @@ func (exe *Executor) serialExec(
 	ctx context.Context,
 	obj client.Object,
 	ownerRef metav1.OwnerReference,
-) (result *ctrl.Result, rerr error) {
+) (result *ctrl.Result, failedOperands map[string]bool, rerr error) {
 	ctx, span, _, _ := exe.inst.Start(ctx, "serial-exec")
 	defer span.End()
 
 	result = nil
+
+	failedOperands = make(map[string]bool)
 
 	span.AddEvent(
 		"Execute serially",
@@ -141,11 +163,14 @@ func (exe *Executor) serialExec(
 			"Executing operand",
 			trace.WithAttributes(attribute.String("operand-name", op.Name())),
 		)
+		// Initially operand as not failed.
+		failedOperands[op.Name()] = false
 		// Call the run call function. Since this is serial execution, return
 		// if an error occurs.
 		event, err := call(op)(ctx, obj, ownerRef)
 		if err != nil {
 			rerr = kerrors.NewAggregate([]error{rerr, err})
+			failedOperands[op.Name()] = true
 			return
 		}
 		if event != nil {
@@ -167,11 +192,13 @@ func (exe *Executor) concurrentExec(
 	ctx context.Context,
 	obj client.Object,
 	ownerRef metav1.OwnerReference,
-) (result *ctrl.Result, rerr error) {
+) (result *ctrl.Result, failedOperands map[string]bool, rerr error) {
 	ctx, span, _, _ := exe.inst.Start(ctx, "concurrent-exec")
 	defer span.End()
 
 	result = nil
+
+	failedOperands = make(map[string]bool)
 
 	// Wait group to synchronize the go routines.
 	var wg sync.WaitGroup
@@ -185,6 +212,10 @@ func (exe *Executor) concurrentExec(
 	// Error buffered channel to collect all the errors from the go routines.
 	var errChan chan error = make(chan error, totalOperands)
 
+	// String buffered channel to collect the names of operands that have failed
+	// to execute.
+	var failedOperandChan chan string = make(chan string, totalOperands)
+
 	span.AddEvent(
 		"Execute concurrently",
 		trace.WithAttributes(attribute.Int("operand-count", len(ops))),
@@ -196,14 +227,22 @@ func (exe *Executor) concurrentExec(
 			"Executing operand",
 			trace.WithAttributes(attribute.String("operand-name", op.Name())),
 		)
-		go exe.operateWithWaitGroup(&wg, resultChan, errChan, call(op), ctx, obj, ownerRef)
+		// Initially set operand as not failed.
+		failedOperands[op.Name()] = false
+		go exe.operateWithWaitGroup(&wg, resultChan, failedOperandChan, errChan, call(op), ctx, obj, ownerRef, op.Name())
 	}
 	wg.Wait()
 	close(errChan)
+	close(failedOperandChan)
 
-	// Check if any errors were encountere.
+	// Check if any errors were encountered.
 	for err := range errChan {
 		rerr = kerrors.NewAggregate([]error{rerr, err})
+	}
+
+	// Set any failed operands to true.
+	for failedOperand := range failedOperandChan {
+		failedOperands[failedOperand] = true
 	}
 
 	// Check the result channel, if it contains any result, return a result
@@ -228,17 +267,20 @@ func (exe *Executor) concurrentExec(
 func (exe *Executor) operateWithWaitGroup(
 	wg *sync.WaitGroup,
 	resultChan chan ctrl.Result,
+	failedOperandChan chan string,
 	errChan chan error,
 	f func(context.Context, client.Object, metav1.OwnerReference) (eventv1.ReconcilerEvent, error),
 	ctx context.Context,
 	obj client.Object,
 	ownerRef metav1.OwnerReference,
+	operandName string,
 ) {
 	defer wg.Done()
 
 	event, err := f(ctx, obj, ownerRef)
 	if err != nil {
 		errChan <- err
+		failedOperandChan <- operandName
 	}
 
 	// Event is used to determine if a change took place. Send a result to the

--- a/operator/v1/operand/order_test.go
+++ b/operator/v1/operand/order_test.go
@@ -1,0 +1,45 @@
+package operand
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommonStringsInSlices(t *testing.T) {
+	testCases := []struct {
+		a, b, want []string
+	}{
+		{
+			[]string{"a", "b", "c"},
+			[]string{"c", "b", "a"},
+			[]string{"a", "b", "c"},
+		},
+		{
+			[]string{"a", "b", "c"},
+			[]string{"d", "e", "f"},
+			[]string{},
+		},
+		{
+			[]string{"apple", "banana", "cherry"},
+			[]string{"cherry", "apple"},
+			[]string{"apple", "cherry"},
+		},
+		{
+			[]string{},
+			[]string{},
+			[]string{},
+		},
+		{
+			[]string{"dog", "cat", "bird"},
+			[]string{},
+			[]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := commonStringsInSlices(tc.a, tc.b)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("commonStringsInSlices(%v, %v) = %v; want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Current behaviour of the operator means that if any operand in a step fails, the next step cannot proceed.
Here is a representation of the current `OperandOrder` - ie map of execution step number to list of operands to be executed:
```
0: [ before-install-operand storageclass-operand ]
1: [ node-operand ]
2: [ api-manager-operand cli-operand csi-operand metrics-exporter-operand node-manager-operand portal-manager-operand scheduler-operand volumesnapshotclass-operand ]
3: [ after-install-operand ]
```
If any operand in a single step was to fail, the following step will not be executed. This made sense when we had less operands. But now with so many operands being installed concurrently in step 2, it is no longer reasonable to block step 3 if one of these operands should fail.

For example, (as discovered recently) if the `cli-operand` (step 2) fails to install for some reason, the operator will become blocked from installing the PDB which is part of the `after-install-operand` (step 3) - even though these are totally unrelated components.

This PR introduces the concept of `BlockingOperands`. These are specific operands that will keep the existing behaviour (ie block execution from proceeding to the next step), whereas the remaining operands are treated as non-blocking.

A blocking operand is designated as such if **every** operand in the **following** step "requires" that operand. 

So based on the above `OperandOrder` and the existing `requires` parameters (list of operands that an operands requires to be running eg https://github.com/storageos/operator/blob/main/controllers/storageoscluster/api-manager_operand.go#L169), the following operands become `BlockingOperands`:

`before-install-operand` - required by all operands in step 1.
`node-operand` - required by all operands in step 2.
`api-manager-operand` - required by all operands in step 3.
`csi-operand` - required by all operands in step 3.

All other operands are non-blocking - note this does not mean that if they fail once they are ignored. If a non-blocking operand fails it will still be requeued as before, however it will not block the rest of the execution order.